### PR TITLE
fix: windows build

### DIFF
--- a/vote/Dockerfile
+++ b/vote/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:11
 
 WORKDIR /app
-COPY . ./
-RUN ./mvnw clean package
+COPY . ./ 
+RUN sed -i 's/\r$//' ./mvnw && chmod 700 ./mvnw && ./mvnw clean package
 RUN cp ./target/*.jar sanity.jar
 
 EXPOSE 8080


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>
Windows adds CRLF at the end of the files making docker container unable to get the `mvnw` script to work.

This PR removes the `\r` character injected by windows and adds permissions to run the script before running it